### PR TITLE
Execute apt commands as sudo

### DIFF
--- a/port/linux/install_dependency.sh
+++ b/port/linux/install_dependency.sh
@@ -1,9 +1,9 @@
-apt install cmake -y
-apt install g++ -y
+sudo apt install cmake -y
+sudo apt install g++ -y
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 git clone https://github.com/google/benchmark.git google_benchmark && cd google_benchmark && cmake -E make_directory "build" && cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../ && cmake --build "build" --config Release && sudo cmake --build "build" --config Release --target install
-apt install ninja-build -y
+sudo apt install ninja-build -y
 
 rm google_benchmark -rf
 


### PR DESCRIPTION
Otherwise on Ubuntu

```
max@max-VirtualBox:~/pika/pikascript/port/linux$ sh install_dependency.sh # install dependency 
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
info: downloading installer
```

should be the same for other Debian based distros since they use `apt` + `sudo`.