### PR TITLE
Supress error for first run

### DIFF
--- a/port/linux/pull-core.sh
+++ b/port/linux/pull-core.sh
@@ -1,2 +1,2 @@
-rm package/pikascript/pikascript-core -r
-cp ../../src package/pikascript/pikascript-core -r
+rm -rf package/pikascript/pikascript-core
+cp -r ../../src package/pikascript/pikascript-core


### PR DESCRIPTION
Otherwise on the first run if the directory does not exist

```
max@max-VirtualBox:~/pika/pikascript/port/linux$ sh pull-core.sh
rm: cannot remove 'package/pikascript/pikascript-core': No such file or directory
```

the other commands still go through, but users may be confused due to the error message.

Also reorders command arguments to the more common one.