### PR TITLE
fix(pikaobj):  Moved name_buff out of the inner if block so its storage duration covers all code paths

### DIFF
--- a/src/PikaObj.c
+++ b/src/PikaObj.c
@@ -1191,8 +1191,8 @@ static void obj_saveMethodInfo(PikaObj* self, MethodInfo* tInfo) {
         .host_obj = NULL,
     };
     char* name = tInfo->name;
+    char name_buff[PIKA_LINE_BUFF_SIZE / 2] = {0};
     if (NULL == tInfo->name) {
-        char name_buff[PIKA_LINE_BUFF_SIZE / 2] = {0};
         name = strGetFirstToken(name_buff, tInfo->dec, '(');
     }
     /* the first arg_value */


### PR DESCRIPTION
the obj_saveMethodInfo function.

Moved name_buff out of the inner if block so its storage duration covers all code paths. This prevents using pointers to a transient buffer that previously led to #356 :

1. method name/hash mismatches
2. intermittent NameError on lookups
3. misleading integrity diagnostics