### PR TITLE
优化 VM 指令分发热路径

### DIFF
--- a/src/PikaVM.c
+++ b/src/PikaVM.c
@@ -4341,9 +4341,11 @@ static int pikaVM_runInstructUnit(PikaObj* self,
     char* data = PikaVMFrame_getConstWithInstructUnit(vm, ins_unit);
     /* run instruct */
     pika_assert(NULL != vm->vm_thread);
+#if PIKA_DEBUG_BREAK_POINT_MAX
     if (PikaVMFrame_checkBreakPoint(vm)) {
         pika_debug_set_trace(self);
     }
+#endif
 
 #if PIKA_INSTRUCT_EXTENSION_ENABLE
     const VMInstruction* ins = instructUnit_getInstruct(instruct);
@@ -4358,7 +4360,8 @@ static int pikaVM_runInstructUnit(PikaObj* self,
     return_arg = VM_instruct_handler_table[instruct](self, vm, data, &ret_reg);
 #endif
 
-    if (pikaVMFrame_checkErrorStack(vm) != PIKA_RES_OK ||
+    PIKA_RES error_stack_result = pikaVMFrame_checkErrorStack(vm);
+    if (error_stack_result != PIKA_RES_OK ||
         VMSignal_getCtrl() == VM_SIGNAL_CTRL_EXIT) {
         /* raise jmp */
         if (vm->vm_thread->try_state != TRY_STATE_NONE) {
@@ -4370,7 +4373,7 @@ static int pikaVM_runInstructUnit(PikaObj* self,
     }
 
 #if PIKA_BUILTIN_STRUCT_ENABLE
-    int invoke_deepth = PikaVMFrame_getInvokeDeepthNow(vm);
+    int invoke_deepth = instructUnit_getInvokeDeepth(ins_unit);
     if (invoke_deepth > 0) {
         PikaObj* oReg = vm->oreg[invoke_deepth - 1];
         if (NULL != oReg && NULL != return_arg) {
@@ -4424,7 +4427,7 @@ __next_line:
     pc_next = vm->pc + instructUnit_getSize();
 
     /* jump to next line */
-    if (pikaVMFrame_checkErrorStack(vm) != PIKA_RES_OK) {
+    if (error_stack_result != PIKA_RES_OK) {
         while (1) {
             if (pc_next >= (int)PikaVMFrame_getInstructArraySize(vm)) {
                 pc_next = VM_PC_EXIT;


### PR DESCRIPTION
## 目标

根据 Linux gprof 热点证据降低 VM 每条指令的固定分发开销，不改 VM 架构或字节码格式。

## 变更

- `PIKA_DEBUG_BREAK_POINT_MAX=0` 时编译掉每指令断点检查。
- 直接从当前 `ins_unit` 读取 invoke depth，避免重复定位当前指令。
- 同一指令内复用一次 error-stack 检查结果，减少正常路径重复检查。

## Linux 性能证据

同一 D601-VM、同一 Docker 镜像、同一 `fib(20)` bytecode workload；每个 profile 合并 10 个 gmon，每个进程执行 10 次：

- v1.14.0：8.4322s、8.4624s，平均 8.4473s。
- 候选：8.0523s、8.0339s，平均 8.0431s。
- 平均耗时下降 4.79%，等价吞吐提升约 5.03%。
- 分配次数均为 11,072,250，未增加分配。

## 资源与回归

- 相对 v1.14.0：Flash 151676 -> 151740 B，增加 64 B（0.042%）。
- static RAM、Pika heap peak、stack upper bound、RAM peak estimate 全部不变。
- `linux-no-lvgl` Docker workflow 的 build、Linux 单测和 Google Benchmark 全部通过。
- QEMU 仅用于功能路径和资源取证，不作为性能裁决。
