### PR TITLE
修复 Linux 构建脚本吞掉失败

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -36,6 +36,9 @@ jobs:
     - name: PULL_CORE
       run: cd ${{github.workspace}}/port/linux && bash pull-core.sh
 
+    - name: BUILD_SCRIPT_FAIL_FAST_TEST
+      run: cd ${{github.workspace}}/port/linux && sh test-build-fail-fast.sh
+
 #     - name: CHMOD
 #       run: cd ${{github.workspace}}/port/linux/package/pikascript && chmod +x ./rust-msc-latest-linux
 

--- a/port/linux/init.sh
+++ b/port/linux/init.sh
@@ -1,5 +1,6 @@
+set -eu
+
 ROOT=$PWD
-reset
 cp config/pika_config_default.h config/pika_config.h
 
 # Linux core tests do not require optional board or LVGL submodules.
@@ -11,8 +12,10 @@ chmod +x package/pikascript/rust-msc-latest-linux
 cp package/pikascript/rust-msc-latest-linux /bin 
 find package/pikascript/pikascript-lib/pika_lvgl -type f -delete
 find package/pikascript -maxdepth 1 -name 'pika_lvgl.pyi' -type f -delete
-find package/pikascript/pikascript-api -maxdepth 1 \
-    \( -name '__pikaBinding.c' -o -name 'pika_lvgl*.h' \) -type f -delete
+if [ -d package/pikascript/pikascript-api ]; then
+    find package/pikascript/pikascript-api -maxdepth 1 \
+        \( -name '__pikaBinding.c' -o -name 'pika_lvgl*.h' \) -type f -delete
+fi
 cd package/pikascript/pikascript-core
 # git checkout master
 cd $ROOT

--- a/port/linux/only_make.sh
+++ b/port/linux/only_make.sh
@@ -1,3 +1,5 @@
+set -eu
+
 find build -name "*.gcda" -type f -delete
 cd build && rm ./test/pikascript_test -f && ninja
 cd .. && cp ./build/boot/demo06-pikamain/pikascript_demo06-pikamain package/pikascript/pika

--- a/port/linux/test-build-fail-fast.sh
+++ b/port/linux/test-build-fail-fast.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+make_stub() {
+    name=$1
+    body=$2
+    printf '#!/bin/sh\n%s\n' "$body" > "$TMP_ROOT/bin/$name"
+    chmod +x "$TMP_ROOT/bin/$name"
+}
+
+mkdir -p "$TMP_ROOT/bin"
+
+init_root="$TMP_ROOT/init"
+mkdir -p "$init_root/config"
+cp "$SCRIPT_DIR/init.sh" "$init_root/init.sh"
+printf '#define PIKA_CONFIG_ENABLE 1\n' > "$init_root/config/pika_config_default.h"
+printf '#!/bin/sh\nexit 23\n' > "$init_root/update-compiler.sh"
+chmod +x "$init_root/update-compiler.sh"
+git -C "$init_root" init -q
+
+set +e
+(cd "$init_root" && PATH="$TMP_ROOT/bin:$PATH" sh init.sh)
+status=$?
+set -e
+if [ "$status" -ne 23 ]; then
+    echo "init.sh did not preserve generator failure: $status" >&2
+    exit 1
+fi
+
+make_root="$TMP_ROOT/make"
+mkdir -p "$make_root/build/test" "$make_root/package/pikascript"
+cp "$SCRIPT_DIR/only_make.sh" "$make_root/only_make.sh"
+make_stub ninja 'exit 29'
+
+set +e
+(cd "$make_root" && PATH="$TMP_ROOT/bin:$PATH" sh only_make.sh)
+status=$?
+set -e
+if [ "$status" -ne 29 ]; then
+    echo "only_make.sh did not preserve Ninja failure: $status" >&2
+    exit 1
+fi
+if [ -e "$make_root/package/pikascript/pika" ]; then
+    echo "only_make.sh continued after Ninja failure" >&2
+    exit 1
+fi
+
+echo "Linux build scripts fail fast: OK"


### PR DESCRIPTION
目标合并分支: master

修复 #376。

- `init.sh` 和 `only_make.sh` 在首个失败处返回非零退出码。
- 删除与构建无关、在非 TTY 中会失败的 `reset`。
- 首次生成前允许 `pikascript-api` 目录不存在。
- 增加下载/代码生成失败和 Ninja 失败的隔离脚本回归测试。
- 将回归测试接入现有 PR workflow。

验证：
- Docker 隔离失败注入测试通过，保留退出码 23 和 29。
- Docker 中完整 Linux `init.sh && only_make.sh` 成功。
- workflow YAML 解析通过。
- `git diff --check` 通过。

TaskTree: tt_c5710e17-a78d-4006-a839-adc0d276814a
